### PR TITLE
Implement filesystem metadata helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
  "codex-file-search",
  "codex-mcp-client",
  "codex-protocol",
- "dirs",
+ "dirs 6.0.0",
  "env-flags",
  "eventsource-stream",
  "futures",
@@ -451,12 +451,15 @@ dependencies = [
  "codex-common",
  "codex-core",
  "codex-protocol",
+ "dirs 5.0.1",
  "owo-colors",
  "predicates",
  "serde",
  "serde_json",
  "shlex",
+ "tempfile",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -597,11 +600,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -612,7 +636,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.0",
 ]
 
@@ -1936,6 +1960,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.4",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3287,6 +3322,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3319,6 +3363,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
 dependencies = [
  "windows-link 0.2.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3356,6 +3415,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3368,6 +3433,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3377,6 +3448,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3404,6 +3481,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3413,6 +3496,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3428,6 +3517,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3437,6 +3532,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,12 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1"
-chrono = "0.4.40"
+chrono = { version = "0.4.40", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 codex-common = { path = "third_party/codex/codex-rs/common", features = ["elapsed"] }
 codex-core = { path = "third_party/codex/codex-rs/core" }
 codex-protocol = { path = "third_party/codex/codex-rs/protocol" }
+dirs = "5.0.1"
 owo-colors = "4.2.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -23,7 +24,9 @@ tokio = { version = "1", features = [
     "signal",
     "sync",
 ] }
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
+tempfile = "3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+pub mod storage;
 pub mod task;
 pub mod worker;
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,388 @@
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, ensure};
+use chrono::{DateTime, Datelike, Utc};
+use dirs::home_dir;
+use uuid::Uuid;
+
+use crate::task::{TaskId, TaskMetadata};
+
+const METADATA_EXTENSION: &str = "json";
+
+/// Rooted view into the filesystem layout backing Codex tasks.
+#[derive(Clone, Debug)]
+pub struct TaskStore {
+    root: PathBuf,
+}
+
+impl TaskStore {
+    /// Creates a new store rooted at the provided path.
+    pub fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    /// Returns a store rooted at the default `~/.codex/tasks` directory.
+    pub fn default() -> Result<Self> {
+        let home = home_dir().context("failed to locate home directory")?;
+        Ok(Self::new(home.join(".codex").join("tasks")))
+    }
+
+    /// Location on disk where active task files are stored.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Directory containing archived tasks.
+    pub fn archive_root(&self) -> PathBuf {
+        self.root.join("done")
+    }
+
+    /// Ensures the primary directories required by the store exist.
+    pub fn ensure_layout(&self) -> Result<()> {
+        fs::create_dir_all(self.root())
+            .with_context(|| format!("failed to create task root at {}", self.root.display()))?;
+        let archive_root = self.archive_root();
+        fs::create_dir_all(&archive_root).with_context(|| {
+            format!(
+                "failed to create archive root at {}",
+                archive_root.display()
+            )
+        })?;
+        Ok(())
+    }
+
+    /// Ensures the archive bucket for the provided timestamp exists.
+    pub fn ensure_archive_bucket(&self, timestamp: DateTime<Utc>) -> Result<PathBuf> {
+        let bucket = self.archive_bucket(timestamp);
+        fs::create_dir_all(&bucket)
+            .with_context(|| format!("failed to create archive bucket at {}", bucket.display()))?;
+        Ok(bucket)
+    }
+
+    fn archive_bucket(&self, timestamp: DateTime<Utc>) -> PathBuf {
+        let date = timestamp.date_naive();
+        self.archive_root()
+            .join(format!("{:04}", date.year()))
+            .join(format!("{:02}", date.month()))
+            .join(format!("{:02}", date.day()))
+    }
+
+    /// Ensures the archive directory for a specific task exists and returns it.
+    pub fn ensure_archive_task_dir(
+        &self,
+        timestamp: DateTime<Utc>,
+        task_id: &TaskId,
+    ) -> Result<PathBuf> {
+        let dir = self.archive_bucket(timestamp).join(task_id);
+        fs::create_dir_all(&dir)
+            .with_context(|| format!("failed to create archive directory for task {}", task_id))?;
+        Ok(dir)
+    }
+
+    /// Generates a new random identifier for a task.
+    pub fn generate_task_id(&self) -> TaskId {
+        Uuid::new_v4().to_string()
+    }
+
+    /// Returns helpers for interacting with an active task's files.
+    pub fn task(&self, task_id: impl Into<TaskId>) -> TaskPaths {
+        TaskPaths::new(self.root.clone(), task_id.into())
+    }
+
+    /// Returns helpers for interacting with an archived task's files.
+    pub fn archived_task(&self, timestamp: DateTime<Utc>, task_id: impl Into<TaskId>) -> TaskPaths {
+        let id = task_id.into();
+        let dir = self.archive_bucket(timestamp).join(&id);
+        TaskPaths::new(dir, id)
+    }
+
+    /// Writes metadata to disk using the standard layout.
+    pub fn save_metadata(&self, metadata: &TaskMetadata) -> Result<()> {
+        self.task(metadata.id.clone()).write_metadata(metadata)
+    }
+
+    /// Loads metadata for the provided task identifier.
+    pub fn load_metadata(&self, task_id: impl Into<TaskId>) -> Result<TaskMetadata> {
+        let id = task_id.into();
+        self.task(id).read_metadata()
+    }
+}
+
+/// Helper for working with the files associated with a particular task.
+#[derive(Clone, Debug)]
+pub struct TaskPaths {
+    base: PathBuf,
+    task_id: TaskId,
+}
+
+impl TaskPaths {
+    fn new(base: PathBuf, task_id: TaskId) -> Self {
+        Self { base, task_id }
+    }
+
+    /// Returns the identifier associated with these paths.
+    pub fn id(&self) -> &str {
+        &self.task_id
+    }
+
+    /// Returns the directory that contains the task's files.
+    pub fn directory(&self) -> &Path {
+        &self.base
+    }
+
+    fn file_path(&self, extension: &str) -> PathBuf {
+        self.base.join(format!("{}.{}", self.task_id, extension))
+    }
+
+    /// Location of the PID file for the task.
+    pub fn pid_path(&self) -> PathBuf {
+        self.file_path("pid")
+    }
+
+    /// Location of the FIFO used for sending prompts to the worker.
+    pub fn pipe_path(&self) -> PathBuf {
+        self.file_path("pipe")
+    }
+
+    /// Location where the worker writes the transcript log.
+    pub fn log_path(&self) -> PathBuf {
+        self.file_path("log")
+    }
+
+    /// Location that stores the most recent Codex result.
+    pub fn result_path(&self) -> PathBuf {
+        self.file_path("result")
+    }
+
+    /// Location of the structured metadata file.
+    pub fn metadata_path(&self) -> PathBuf {
+        self.file_path(METADATA_EXTENSION)
+    }
+
+    fn ensure_parent(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to prepare directory {}", parent.display()))?;
+        }
+        Ok(())
+    }
+
+    /// Persists structured metadata for the task to disk.
+    pub fn write_metadata(&self, metadata: &TaskMetadata) -> Result<()> {
+        ensure!(
+            metadata.id == self.task_id,
+            "metadata id {} does not match path {}",
+            metadata.id,
+            self.task_id
+        );
+        let path = self.metadata_path();
+        self.ensure_parent(&path)?;
+        let payload = serde_json::to_string_pretty(metadata)
+            .with_context(|| format!("failed to serialize metadata for task {}", self.task_id))?;
+        fs::write(&path, payload)
+            .with_context(|| format!("failed to write metadata for task {}", self.task_id))?;
+        Ok(())
+    }
+
+    /// Loads structured metadata for the task from disk.
+    pub fn read_metadata(&self) -> Result<TaskMetadata> {
+        let path = self.metadata_path();
+        let data = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read metadata for task {}", self.task_id))?;
+        let metadata: TaskMetadata = serde_json::from_str(&data)
+            .with_context(|| format!("failed to parse metadata for task {}", self.task_id))?;
+        ensure!(
+            metadata.id == self.task_id,
+            "metadata id {} does not match path {}",
+            metadata.id,
+            self.task_id
+        );
+        Ok(metadata)
+    }
+
+    /// Writes the PID of the associated worker to disk.
+    pub fn write_pid(&self, pid: i32) -> Result<()> {
+        let path = self.pid_path();
+        self.ensure_parent(&path)?;
+        fs::write(&path, pid.to_string())
+            .with_context(|| format!("failed to write pid for task {}", self.task_id))?;
+        Ok(())
+    }
+
+    /// Reads the PID of the associated worker. Returns `None` if the PID file is missing.
+    pub fn read_pid(&self) -> Result<Option<i32>> {
+        let path = self.pid_path();
+        match fs::read_to_string(&path) {
+            Ok(raw) => {
+                let value = raw
+                    .trim()
+                    .parse::<i32>()
+                    .with_context(|| format!("failed to parse pid for task {}", self.task_id))?;
+                Ok(Some(value))
+            }
+            Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+            Err(err) => {
+                Err(err).with_context(|| format!("failed to read pid for task {}", self.task_id))
+            }
+        }
+    }
+
+    /// Removes the PID file, ignoring missing files.
+    pub fn remove_pid(&self) -> Result<()> {
+        let path = self.pid_path();
+        match fs::remove_file(&path) {
+            Ok(_) => Ok(()),
+            Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err)
+                .with_context(|| format!("failed to remove pid file for task {}", self.task_id)),
+        }
+    }
+
+    /// Removes the pipe file, ignoring missing files.
+    pub fn remove_pipe(&self) -> Result<()> {
+        let path = self.pipe_path();
+        match fs::remove_file(&path) {
+            Ok(_) => Ok(()),
+            Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+            Err(err) => {
+                Err(err).with_context(|| format!("failed to remove pipe for task {}", self.task_id))
+            }
+        }
+    }
+
+    /// Writes the last Codex result for the task to disk.
+    pub fn write_last_result(&self, contents: &str) -> Result<()> {
+        let path = self.result_path();
+        self.ensure_parent(&path)?;
+        fs::write(&path, contents)
+            .with_context(|| format!("failed to write result for task {}", self.task_id))?;
+        Ok(())
+    }
+
+    /// Reads the last Codex result for the task, if present.
+    pub fn read_last_result(&self) -> Result<Option<String>> {
+        let path = self.result_path();
+        match fs::read_to_string(&path) {
+            Ok(contents) => Ok(Some(contents)),
+            Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+            Err(err) => {
+                Err(err).with_context(|| format!("failed to read result for task {}", self.task_id))
+            }
+        }
+    }
+
+    /// Ensures the directory holding task files exists.
+    pub fn ensure_directory(&self) -> Result<()> {
+        fs::create_dir_all(self.directory()).with_context(|| {
+            format!(
+                "failed to create task directory {}",
+                self.directory().display()
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use tempfile::tempdir;
+
+    #[test]
+    fn ensure_layout_creates_directories() {
+        let tmp = tempdir().expect("tempdir");
+        let store = TaskStore::new(tmp.path().join(".codex").join("tasks"));
+        store.ensure_layout().expect("layout should be created");
+        assert!(store.root().exists());
+        assert!(store.archive_root().exists());
+    }
+
+    #[test]
+    fn metadata_round_trip() {
+        let tmp = tempdir().expect("tempdir");
+        let store = TaskStore::new(tmp.path().join("store"));
+        store.ensure_layout().expect("layout");
+        let id = "abc-123".to_string();
+        let files = store.task(id.clone());
+        let metadata = TaskMetadata::new(
+            id.clone(),
+            Some("Example".into()),
+            crate::task::TaskState::Idle,
+        );
+        files.write_metadata(&metadata).expect("write metadata");
+        let loaded = files.read_metadata().expect("read metadata");
+        assert_eq!(metadata, loaded);
+    }
+
+    #[test]
+    fn pid_read_write_and_remove() {
+        let tmp = tempdir().expect("tempdir");
+        let store = TaskStore::new(tmp.path().join("root"));
+        store.ensure_layout().expect("layout");
+        let files = store.task("task-1".to_string());
+        assert_eq!(files.read_pid().expect("read pid"), None);
+        files.write_pid(4242).expect("write pid");
+        assert_eq!(files.read_pid().expect("read pid"), Some(4242));
+        files.remove_pid().expect("remove pid");
+        assert_eq!(files.read_pid().expect("read pid"), None);
+    }
+
+    #[test]
+    fn last_result_round_trip() {
+        let tmp = tempdir().expect("tempdir");
+        let store = TaskStore::new(tmp.path().join("root"));
+        store.ensure_layout().expect("layout");
+        let files = store.task("task-42".to_string());
+        assert_eq!(files.read_last_result().expect("read result"), None);
+        files
+            .write_last_result("some result")
+            .expect("write result");
+        assert_eq!(
+            files.read_last_result().expect("read result"),
+            Some("some result".to_string())
+        );
+    }
+
+    #[test]
+    fn ensure_archive_bucket_creates_hierarchy() {
+        let tmp = tempdir().expect("tempdir");
+        let store = TaskStore::new(tmp.path().join("root"));
+        store.ensure_layout().expect("layout");
+        let timestamp = Utc
+            .with_ymd_and_hms(2024, 3, 14, 15, 9, 26)
+            .single()
+            .expect("valid timestamp");
+        let bucket = store
+            .ensure_archive_bucket(timestamp)
+            .expect("create bucket");
+        assert!(bucket.exists());
+        assert!(bucket.ends_with("14"));
+        let dir = store
+            .ensure_archive_task_dir(timestamp, &"task-xyz".to_string())
+            .expect("archive dir");
+        assert!(dir.exists());
+        assert!(dir.ends_with("task-xyz"));
+    }
+
+    #[test]
+    fn archived_task_paths_include_task_directory() {
+        let tmp = tempdir().expect("tempdir");
+        let store = TaskStore::new(tmp.path().join("root"));
+        store.ensure_layout().expect("layout");
+        let timestamp = Utc
+            .with_ymd_and_hms(2024, 1, 2, 3, 4, 5)
+            .single()
+            .expect("timestamp");
+        let paths = store.archived_task(timestamp, "task-abc".to_string());
+        let expected_dir = store
+            .archive_root()
+            .join("2024")
+            .join("01")
+            .join("02")
+            .join("task-abc");
+        assert_eq!(paths.directory(), expected_dir.as_path());
+        assert_eq!(paths.log_path(), expected_dir.join("task-abc.log"));
+    }
+}


### PR DESCRIPTION
## Summary
- add a `TaskStore` helper that manages the `~/.codex/tasks` layout and archive buckets
- persist task metadata, pid/result helpers, and uuid generation for task files
- derive serde support for `TaskMetadata` and add unit tests covering filesystem utilities

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d01a8dadd8832ebca325ce7fac2fba