### PR TITLE
Implement worker runtime loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,7 @@ dependencies = [
  "codex-core",
  "codex-protocol",
  "dirs 5.0.1",
+ "libc",
  "owo-colors",
  "predicates",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tokio = { version = "1", features = [
     "sync",
 ] }
 uuid = { version = "1", features = ["v4"] }
+libc = "0.2"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/worker/child.rs
+++ b/src/worker/child.rs
@@ -1,11 +1,23 @@
 use std::convert::TryFrom;
 use std::env;
-use std::path::PathBuf;
+use std::ffi::CString;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::os::fd::AsRawFd;
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use codex_core::config::{Config, ConfigOverrides};
+use codex_core::protocol::Event;
+use tokio::fs::OpenOptions as TokioOpenOptions;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::sync::mpsc;
 
 use crate::storage::{TaskPaths, TaskStore};
 use crate::task::TaskId;
+use crate::worker::event_processor_with_human_output::EventProcessorWithHumanOutput;
+use crate::worker::runner;
 
 /// Environment variable that carries the optional title for the worker.
 pub const TITLE_ENV_VAR: &str = "CODEX_TASK_TITLE";
@@ -55,9 +67,10 @@ impl WorkerConfig {
 
 /// Runs the worker process until it is signalled to exit.
 pub async fn run_worker(config: WorkerConfig) -> Result<()> {
-    let store = config.store();
+    let worker_config = config;
+    let store = worker_config.store();
     store.ensure_layout()?;
-    let paths = store.task(config.task_id.clone());
+    let paths = store.task(worker_config.task_id.clone());
     paths.ensure_directory()?;
 
     let pid = std::process::id();
@@ -70,11 +83,88 @@ pub async fn run_worker(config: WorkerConfig) -> Result<()> {
         return Ok(());
     }
 
-    tokio::signal::ctrl_c()
-        .await
-        .context("failed while waiting for shutdown signal")?;
+    let pipe_path = paths.pipe_path();
+    create_pipe(&pipe_path)
+        .with_context(|| format!("failed to create prompt pipe at {}", pipe_path.display()))?;
 
-    Ok(())
+    let log_path = paths.log_path();
+    let log_file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&log_path)
+        .with_context(|| format!("failed to open log file at {}", log_path.display()))?;
+
+    redirect_stdio_to(&log_file).context("failed to redirect worker output to log file")?;
+
+    let codex_config = Config::load_with_cli_overrides(Vec::new(), ConfigOverrides::default())
+        .context("failed to load Codex configuration")?;
+
+    let mut event_processor = EventProcessorWithHumanOutput::create_with_ansi(
+        false,
+        &codex_config,
+        Some(paths.result_path()),
+    );
+
+    let runner::ChildHandles {
+        child,
+        stdout,
+        stdin,
+    } = runner::spawn_codex_proto().await?;
+
+    let (event_tx, mut event_rx) = mpsc::unbounded_channel::<Event>();
+    tokio::spawn(async move {
+        let mut lines = BufReader::new(stdout).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<Event>(trimmed) {
+                Ok(event) => {
+                    if event_tx.send(event).is_err() {
+                        break;
+                    }
+                }
+                Err(err) => {
+                    eprintln!("Failed to parse event from codex proto: {err}");
+                }
+            }
+        }
+    });
+
+    let pipe_file = TokioOpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&pipe_path)
+        .await
+        .with_context(|| format!("failed to open prompt pipe at {}", pipe_path.display()))?;
+
+    let result = runner::run_event_loop(
+        child,
+        stdin,
+        &mut event_processor,
+        &codex_config,
+        &mut event_rx,
+        pipe_file,
+        worker_config.initial_prompt.clone(),
+    )
+    .await;
+
+    if let Err(err) = std::io::stdout().flush() {
+        eprintln!("failed to flush worker log: {err:#}");
+    }
+
+    if let Err(err) = paths.remove_pipe() {
+        eprintln!("failed to remove pipe for task {}: {err:#}", paths.id());
+    }
+    if let Err(err) = paths.remove_pid() {
+        eprintln!("failed to remove pid file for task {}: {err:#}", paths.id());
+    }
+
+    drop(log_file);
+
+    result
 }
 
 fn should_exit_after_start() -> bool {
@@ -87,10 +177,44 @@ fn should_exit_after_start() -> bool {
     }
 }
 
+fn create_pipe(path: &Path) -> Result<()> {
+    if path.exists() {
+        fs::remove_file(path)
+            .with_context(|| format!("failed to remove existing pipe at {}", path.display()))?;
+    }
+
+    let c_path = CString::new(path.as_os_str().as_bytes())
+        .context("pipe path contained interior null bytes")?;
+    let mode = 0o600;
+    let result = unsafe { libc::mkfifo(c_path.as_ptr(), mode) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error())
+            .with_context(|| format!("failed to create pipe at {}", path.display()));
+    }
+
+    Ok(())
+}
+
+fn redirect_stdio_to(log: &std::fs::File) -> Result<()> {
+    let fd = log.as_raw_fd();
+    unsafe {
+        if libc::dup2(fd, libc::STDOUT_FILENO) == -1 {
+            return Err(std::io::Error::last_os_error())
+                .context("failed to redirect stdout to log file");
+        }
+        if libc::dup2(fd, libc::STDERR_FILENO) == -1 {
+            return Err(std::io::Error::last_os_error())
+                .context("failed to redirect stderr to log file");
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::fs;
+    use std::os::unix::fs::FileTypeExt;
     use std::sync::Mutex;
 
     use crate::storage::TaskStore;
@@ -163,5 +287,14 @@ mod tests {
         let expected = i32::try_from(std::process::id()).expect("pid fits in i32");
         assert_eq!(contents.trim(), expected.to_string());
         remove_env(EXIT_AFTER_START_ENV_VAR);
+    }
+
+    #[test]
+    fn create_pipe_creates_fifo() {
+        let tmp = tempdir().expect("tempdir");
+        let path = tmp.path().join("pipe");
+        create_pipe(&path).expect("create pipe");
+        let metadata = fs::metadata(&path).expect("metadata");
+        assert!(metadata.file_type().is_fifo(), "expected FIFO at {path:?}");
     }
 }


### PR DESCRIPTION
## Summary
- port the worker into a full runtime loop that creates the FIFO pipe, launches codex proto, and forwards prompts from the pipe while updating logs and results
- reuse the existing event loop for both interactive and worker flows by allowing an injected input stream and optional initial prompt
- add libc dependency plus helpers to build FIFOs, redirect stdio to the log file, and clean up pipes on exit

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d0403a1074832e871248cd662b9aca