### PR TITLE
Implement start command

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -34,6 +34,8 @@ pub struct TaskMetadata {
     pub updated_at: DateTime<Utc>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_result: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub initial_prompt: Option<String>,
 }
 
 impl TaskMetadata {
@@ -47,6 +49,7 @@ impl TaskMetadata {
             created_at: now,
             updated_at: now,
             last_result: None,
+            initial_prompt: None,
         }
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,4 +1,10 @@
+use std::{fs, thread, time::Duration};
+
 use assert_cmd::Command;
+use serde::Deserialize;
+use serde_json::from_str;
+use tempfile::tempdir;
+use uuid::Uuid;
 
 const BIN: &str = "codex-tasks";
 
@@ -18,16 +24,67 @@ fn help_lists_supported_subcommands() {
 }
 
 #[test]
-fn subcommands_return_not_implemented_errors() {
-    let mut cmd = Command::cargo_bin(BIN).expect("binary should build");
-    cmd.arg("start");
-    cmd.assert()
-        .failure()
-        .stderr(predicates::str::contains("`start` is not implemented yet"));
-
+fn unfinished_subcommands_return_not_implemented_errors() {
     let mut cmd = Command::cargo_bin(BIN).expect("binary should build");
     cmd.args(["ls", "--state", "RUNNING"]);
     cmd.assert()
         .failure()
         .stderr(predicates::str::contains("`ls` is not implemented yet"));
+
+    let mut cmd = Command::cargo_bin(BIN).expect("binary should build");
+    cmd.args(["status", "fake-task"]);
+    cmd.assert()
+        .failure()
+        .stderr(predicates::str::contains("`status` is not implemented yet"));
+}
+
+#[test]
+fn start_command_creates_task_and_launches_worker() {
+    let tmp = tempdir().expect("tempdir");
+
+    let mut cmd = Command::cargo_bin(BIN).expect("binary should build");
+    cmd.arg("start")
+        .arg("--title")
+        .arg("Integration Title")
+        .arg("Initial prompt")
+        .env("HOME", tmp.path())
+        .env("CODEX_TASKS_EXIT_AFTER_START", "1");
+    let assert = cmd.assert().success();
+    let output = String::from_utf8(assert.get_output().stdout.clone()).expect("stdout utf8");
+    let task_id = output.trim();
+    assert!(!task_id.is_empty(), "start should print the task id");
+    Uuid::parse_str(task_id).expect("task id should be a valid uuid");
+
+    let store_root = tmp.path().join(".codex").join("tasks");
+    let metadata_path = store_root.join(format!("{task_id}.json"));
+    assert!(
+        metadata_path.exists(),
+        "metadata file should exist at {:?}",
+        metadata_path
+    );
+    let metadata_contents = fs::read_to_string(&metadata_path).expect("metadata readable");
+    #[derive(Debug, Deserialize)]
+    struct Metadata {
+        id: String,
+        #[serde(default)]
+        title: Option<String>,
+        state: String,
+        #[serde(default)]
+        initial_prompt: Option<String>,
+    }
+    let metadata: Metadata = from_str(&metadata_contents).expect("metadata valid json");
+    assert_eq!(metadata.id, task_id);
+    assert_eq!(metadata.title.as_deref(), Some("Integration Title"));
+    assert_eq!(metadata.state, "RUNNING");
+    assert_eq!(metadata.initial_prompt.as_deref(), Some("Initial prompt"));
+
+    let pid_path = store_root.join(format!("{task_id}.pid"));
+    let mut attempts = 0;
+    while !pid_path.exists() && attempts < 20 {
+        attempts += 1;
+        thread::sleep(Duration::from_millis(50));
+    }
+    assert!(pid_path.exists(), "worker should record its pid");
+    let pid_contents = fs::read_to_string(pid_path).expect("pid readable");
+    assert!(!pid_contents.trim().is_empty(), "pid should not be empty");
 }


### PR DESCRIPTION
## Summary
- implement the `start` command to prepare the task store, persist metadata (including optional prompt/title), spawn the worker process, and print the new task id
- extend task metadata to capture an initial prompt so CLI arguments are recorded on disk
- add an integration test for the start workflow and keep other CLI subcommands marked as not yet implemented

## Testing
- cargo fmt
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d13c89a530832e84655ecf01b63d0c