### PR TITLE
Implement archive command and reorganize task storage layout

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -51,17 +51,17 @@
    - **Depends on:** Tasks 2 & 4
 
 9. **Implement `ls` command**
-   - Enumerate `tasks/` and `tasks/done/**` directories.
+   - Enumerate `tasks/` and `tasks/archive/**` directories.
    - Aggregate metadata for each task; support `--state` filters.
    - **Depends on:** Task 2
 
 10. **Implement `log` command**
     - Tail/read `<task_id>.log` with options `-n`, `-f` (follow).
-    - Respect archived tasks (log location under `done/…`).
+    - Respect archived tasks (log location under `archive/…`).
     - **Depends on:** Task 2
 
 11. **Implement `archive` command**
-    - Move task files to dated `done/` subdirectory.
+    - Move task files to dated `archive/` subdirectory.
     - Prevent archiving RUNNING tasks without `stop`.
     - **Depends on:** Tasks 2, 8
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,9 +1,7 @@
-use std::collections::VecDeque;
-use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use serde_json::json;
 
 use crate::storage::TaskStore;
@@ -112,7 +110,7 @@ fn load_status_record(store: &TaskStore, task_id: &str) -> Result<TaskStatusReco
             let derived_state = derive_active_state(&metadata.state, pid);
             metadata.state = derived_state;
             if metadata.last_result.is_none() {
-                metadata.last_result = read_result_file(&directory, &metadata.id)?;
+                metadata.last_result = paths.read_last_result()?;
             }
             Ok(TaskStatusRecord {
                 metadata,
@@ -128,89 +126,20 @@ fn load_status_record(store: &TaskStore, task_id: &str) -> Result<TaskStatusReco
                 return Err(err);
             }
 
-            let Some((directory, mut metadata)) = find_archived_metadata(store, task_id)? else {
+            let Some((paths, mut metadata)) = store.find_archived_task(task_id)? else {
                 bail!("task {task_id} was not found in the task store");
             };
             metadata.state = TaskState::Archived;
             if metadata.last_result.is_none() {
-                metadata.last_result = read_result_file(&directory, &metadata.id)?;
+                metadata.last_result = paths.read_last_result()?;
             }
             Ok(TaskStatusRecord {
                 metadata,
-                location: TaskLocation::Archived(directory),
+                location: TaskLocation::Archived(paths.directory().to_path_buf()),
                 pid: None,
             })
         }
     }
-}
-
-fn read_result_file(directory: &Path, task_id: &str) -> Result<Option<String>> {
-    let path = directory.join(format!("{}.result", task_id));
-    match fs::read_to_string(&path) {
-        Ok(contents) => Ok(Some(contents)),
-        Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
-        Err(err) => {
-            Err(err).with_context(|| format!("failed to read last result from {}", path.display()))
-        }
-    }
-}
-
-fn find_archived_metadata(
-    store: &TaskStore,
-    task_id: &str,
-) -> Result<Option<(PathBuf, TaskMetadata)>> {
-    let archive_root = store.archive_root();
-    if !archive_root.exists() {
-        return Ok(None);
-    }
-
-    let mut queue = VecDeque::from([archive_root]);
-    let target_file = format!("{}.json", task_id);
-
-    while let Some(dir) = queue.pop_front() {
-        let entries = match fs::read_dir(&dir) {
-            Ok(entries) => entries,
-            Err(err) if err.kind() == ErrorKind::NotFound => continue,
-            Err(err) => {
-                return Err(err).with_context(|| {
-                    format!("failed to read archive directory {}", dir.display())
-                });
-            }
-        };
-
-        for entry in entries {
-            let entry = entry.with_context(|| {
-                format!("failed to iterate archive directory {}", dir.display())
-            })?;
-            let path = entry.path();
-            if path.is_dir() {
-                queue.push_back(path);
-                continue;
-            }
-
-            if path
-                .file_name()
-                .is_some_and(|name| name == target_file.as_str())
-            {
-                let data = fs::read_to_string(&path).with_context(|| {
-                    format!("failed to read archived metadata at {}", path.display())
-                })?;
-                let metadata: TaskMetadata = serde_json::from_str(&data).with_context(|| {
-                    format!("failed to parse archived metadata at {}", path.display())
-                })?;
-                if metadata.id != task_id {
-                    continue;
-                }
-                let directory = path
-                    .parent()
-                    .map(Path::to_path_buf)
-                    .unwrap_or_else(|| store.archive_root());
-                return Ok(Some((directory, metadata)));
-            }
-        }
-    }
-
-    Ok(None)
 }
 
 fn derive_active_state(metadata_state: &TaskState, pid: Option<i32>) -> TaskState {

--- a/src/worker/launcher.rs
+++ b/src/worker/launcher.rs
@@ -49,7 +49,12 @@ pub fn spawn_worker(request: WorkerLaunchRequest) -> Result<Child> {
     command.arg("--task-id");
     command.arg(task_paths.id());
     command.arg("--store-root");
-    command.arg(task_paths.directory());
+    let store_root = task_paths
+        .directory()
+        .parent()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| task_paths.directory().to_path_buf());
+    command.arg(store_root);
 
     if let Some(title) = title {
         command.env(TITLE_ENV_VAR, title);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,8 +1,9 @@
+use std::collections::VecDeque;
 use std::ffi::CString;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::os::unix::ffi::OsStrExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command as StdCommand;
 use std::sync::mpsc;
 use std::thread;
@@ -12,8 +13,8 @@ use assert_cmd::Command;
 use chrono::{TimeZone, Utc};
 use predicates::prelude::PredicateBooleanExt;
 use serde::Deserialize;
-use serde_json::{from_str, json, Value};
-use tempfile::{tempdir, TempDir};
+use serde_json::{Value, from_str, json};
+use tempfile::{TempDir, tempdir};
 use uuid::Uuid;
 
 const BIN: &str = "codex-tasks";
@@ -36,15 +37,20 @@ fn help_lists_supported_subcommands() {
 #[test]
 fn unfinished_subcommands_return_not_implemented_errors() {
     let mut cmd = Command::cargo_bin(BIN).expect("binary should build");
-    cmd.args(["archive", "task-xyz"]);
-    cmd.assert()
-        .failure()
-        .stderr(predicates::str::contains("`archive` is not implemented yet"));
-}
+    let archive_root = task_root.join("archive");
+    let active_dir = task_root.join(active_id);
+    fs::create_dir_all(&active_dir).expect("active dir");
+        active_dir.join("task.json"),
+        archived_dir.join("task.json"),
+    let archive_root = task_root.join("archive");
+    let running_dir = task_root.join(running_id);
+    fs::create_dir_all(&running_dir).expect("running dir");
+        running_dir.join("task.json"),
 
-#[test]
-fn ls_lists_active_and_archived_tasks() {
-    let home = tempdir().expect("tempdir");
+        archived_dir.join("task.json"),
+    let task_dir = store_root.join(task_id);
+    let metadata_path = task_dir.join("task.json");
+    let pid_path = task_dir.join("task.pid");
     let task_root = home.path().join(".codex").join("tasks");
     let archive_root = task_root.join("done");
     fs::create_dir_all(&archive_root).expect("layout");
@@ -265,10 +271,29 @@ fn send_rejects_died_tasks() {
 fn send_rejects_archived_tasks() {
     let tmp = tempdir().expect("tempdir");
     let tasks_dir = tmp.path().join(".codex").join("tasks");
-    fs::create_dir_all(&tasks_dir).expect("tasks dir");
-
     let task_id = "archived-task";
-    write_metadata(&tasks_dir, task_id, "ARCHIVED");
+    let archived_dir = tasks_dir
+        .join("archive")
+        .join("2024")
+        .join("01")
+        .join("02")
+        .join(task_id);
+    fs::create_dir_all(&archived_dir).expect("archived dir");
+    let timestamp = Utc
+        .with_ymd_and_hms(2024, 1, 2, 3, 4, 5)
+        .single()
+        .expect("timestamp");
+    let metadata = json!({
+        "id": task_id,
+        "state": "ARCHIVED",
+        "created_at": timestamp.to_rfc3339(),
+        "updated_at": timestamp.to_rfc3339(),
+    });
+    fs::write(
+        archived_dir.join("task.json"),
+        serde_json::to_string_pretty(&metadata).expect("serialize"),
+    )
+    .expect("write archived metadata");
 
     let mut cmd = Command::cargo_bin(BIN).expect("binary should build");
     cmd.env("HOME", tmp.path())
@@ -286,7 +311,7 @@ fn send_writes_prompt_to_pipe() {
 
     let task_id = "active-task";
     write_metadata(&tasks_dir, task_id, "IDLE");
-    let pipe_path = tasks_dir.join(format!("{task_id}.pipe"));
+    let pipe_path = tasks_dir.join(task_id).join("task.pipe");
     create_pipe(&pipe_path);
 
     let (tx, rx) = mpsc::channel();
@@ -339,7 +364,7 @@ fn send_errors_when_pipe_has_no_reader() {
 
     let task_id = "no-reader-task";
     write_metadata(&tasks_dir, task_id, "IDLE");
-    let pipe_path = tasks_dir.join(format!("{task_id}.pipe"));
+    let pipe_path = tasks_dir.join(task_id).join("task.pipe");
     create_pipe(&pipe_path);
 
     let mut cmd = Command::cargo_bin(BIN).expect("binary should build");
@@ -356,17 +381,117 @@ fn send_errors_when_pipe_has_no_reader() {
 fn stop_handles_missing_task_gracefully() {
     let tmp = tempdir().expect("tempdir");
     let mut cmd = Command::cargo_bin(BIN).expect("binary should build");
-    cmd.env("HOME", tmp.path())
-        .args(["stop", "task-xyz"]);
-    cmd.assert()
-        .success()
-        .stdout(predicates::str::contains(
-            "Task task-xyz is not running; nothing to stop.",
+    cmd.env("HOME", tmp.path()).args(["stop", "task-xyz"]);
+    cmd.assert().success().stdout(predicates::str::contains(
+        "Task task-xyz is not running; nothing to stop.",
+    ));
+}
+
+#[test]
+fn archive_moves_task_into_archive() {
+    let tmp = tempdir().expect("tempdir");
+    let home = tmp.path();
+    let tasks_dir = home.join(".codex").join("tasks");
+    let task_id = "task-archive";
+    let task_dir = tasks_dir.join(task_id);
+    fs::create_dir_all(&task_dir).expect("task dir");
+    let timestamp = Utc
+        .with_ymd_and_hms(2024, 6, 1, 12, 0, 0)
+        .single()
+        .expect("timestamp");
+    let metadata = json!({
+        "id": task_id,
+        "state": "STOPPED",
+        "created_at": timestamp.to_rfc3339(),
+        "updated_at": timestamp.to_rfc3339(),
+    });
+    fs::write(
+        task_dir.join("task.json"),
+        serde_json::to_string_pretty(&metadata).expect("serialize"),
+    )
+    .expect("write metadata");
+    fs::write(task_dir.join("task.log"), "log contents").expect("log");
+    fs::write(task_dir.join("task.result"), "final result").expect("result");
+    fs::write(task_dir.join("task.pid"), "1234").expect("pid");
+    create_pipe(task_dir.join("task.pipe").as_path());
+
+    let mut cmd = Command::cargo_bin(BIN).expect("binary should build");
+    let assert = cmd
+        .env("HOME", home)
+        .args(["archive", task_id])
+        .assert()
+        .success();
+
+    assert!(
+        !task_dir.exists(),
+        "active task directory should be moved into the archive"
+    );
+
+    let archive_root = tasks_dir.join("archive");
+    let archived_dir = find_task_directory(&archive_root, task_id).expect("archived dir");
+    let metadata_contents =
+        fs::read_to_string(archived_dir.join("task.json")).expect("archived metadata");
+    let value: Value = serde_json::from_str(&metadata_contents).expect("valid metadata");
+    assert_eq!(value["id"], task_id);
+    assert_eq!(value["state"], "ARCHIVED");
+    assert_eq!(
+        fs::read_to_string(archived_dir.join("task.log")).expect("archived log"),
+        "log contents"
+    );
+    assert_eq!(
+        fs::read_to_string(archived_dir.join("task.result")).expect("archived result"),
+        "final result"
+    );
+    assert!(
+        !archived_dir.join("task.pid").exists(),
+        "pid file should be removed before archiving"
+    );
+    assert!(
+        !archived_dir.join("task.pipe").exists(),
+        "pipe should be removed before archiving"
+    );
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("stdout utf8");
+    assert!(stdout.contains("archived to"));
+}
+
+#[test]
+fn archive_rejects_running_task() {
+    let tmp = tempdir().expect("tempdir");
+    let home = tmp.path();
+    let tasks_dir = home.join(".codex").join("tasks");
+    let task_id = "task-running";
+    let task_dir = tasks_dir.join(task_id);
+    fs::create_dir_all(&task_dir).expect("task dir");
+    let timestamp = Utc
+        .with_ymd_and_hms(2024, 6, 2, 1, 0, 0)
+        .single()
+        .expect("timestamp");
+    let metadata = json!({
+        "id": task_id,
+        "state": "RUNNING",
+        "created_at": timestamp.to_rfc3339(),
+        "updated_at": timestamp.to_rfc3339(),
+    });
+    fs::write(
+        task_dir.join("task.json"),
+        serde_json::to_string_pretty(&metadata).expect("serialize"),
+    )
+    .expect("write metadata");
+
+    let mut cmd = Command::cargo_bin(BIN).expect("binary should build");
+    cmd.env("HOME", home)
+        .args(["archive", task_id])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "task task-running is RUNNING; stop it before archiving",
         ));
 }
 
 fn write_metadata(tasks_dir: &Path, task_id: &str, state: &str) {
-    let metadata_path = tasks_dir.join(format!("{task_id}.json"));
+    let task_dir = tasks_dir.join(task_id);
+    fs::create_dir_all(&task_dir).expect("task directory");
+    let metadata_path = task_dir.join("task.json");
     let timestamp = Utc::now().to_rfc3339();
     let payload = json!({
         "id": task_id,
@@ -393,6 +518,29 @@ fn create_pipe(path: &Path) {
     }
 }
 
+fn find_task_directory(root: &Path, task_id: &str) -> Option<PathBuf> {
+    if !root.exists() {
+        return None;
+    }
+    let mut queue = VecDeque::from([root.to_path_buf()]);
+    while let Some(dir) = queue.pop_front() {
+        if dir
+            .file_name()
+            .and_then(|value| value.to_str())
+            .is_some_and(|name| name == task_id)
+        {
+            return Some(dir);
+        }
+        for entry in fs::read_dir(&dir).expect("read archive directory") {
+            let entry = entry.expect("archive entry");
+            if entry.file_type().expect("entry type").is_dir() {
+                queue.push_back(entry.path());
+            }
+        }
+    }
+    None
+}
+
 #[test]
 fn status_reports_idle_task_in_json() {
     let temp = TempDir::new().expect("temp dir");
@@ -400,7 +548,8 @@ fn status_reports_idle_task_in_json() {
     let task_id = "task-123";
     let created_at = "2024-05-01T12:34:56Z";
     let store_root = home.join(".codex").join("tasks");
-    fs::create_dir_all(&store_root).expect("store root");
+    let task_dir = store_root.join(task_id);
+    fs::create_dir_all(&task_dir).expect("store root");
     let metadata = serde_json::json!({
         "id": task_id,
         "title": "Example task",
@@ -409,7 +558,7 @@ fn status_reports_idle_task_in_json() {
         "updated_at": created_at
     });
     fs::write(
-        store_root.join(format!("{task_id}.json")),
+        task_dir.join("task.json"),
         serde_json::to_string_pretty(&metadata).unwrap(),
     )
     .expect("metadata");
@@ -432,7 +581,8 @@ fn status_flags_missing_pid_as_died() {
     let task_id = "task-456";
     let timestamp = "2024-05-02T00:00:00Z";
     let store_root = home.join(".codex").join("tasks");
-    fs::create_dir_all(&store_root).expect("store root");
+    let task_dir = store_root.join(task_id);
+    fs::create_dir_all(&task_dir).expect("store root");
     let metadata = serde_json::json!({
         "id": task_id,
         "state": "RUNNING",
@@ -440,7 +590,7 @@ fn status_flags_missing_pid_as_died() {
         "updated_at": timestamp
     });
     fs::write(
-        store_root.join(format!("{task_id}.json")),
+        task_dir.join("task.json"),
         serde_json::to_string_pretty(&metadata).unwrap(),
     )
     .expect("metadata");
@@ -461,7 +611,8 @@ fn status_reports_running_task_when_pid_alive() {
     let task_id = "task-789";
     let timestamp = "2024-05-03T06:07:08Z";
     let store_root = home.join(".codex").join("tasks");
-    fs::create_dir_all(&store_root).expect("store root");
+    let task_dir = store_root.join(task_id);
+    fs::create_dir_all(&task_dir).expect("store root");
     let metadata = serde_json::json!({
         "id": task_id,
         "state": "RUNNING",
@@ -469,7 +620,7 @@ fn status_reports_running_task_when_pid_alive() {
         "updated_at": timestamp
     });
     fs::write(
-        store_root.join(format!("{task_id}.json")),
+        task_dir.join("task.json"),
         serde_json::to_string_pretty(&metadata).unwrap(),
     )
     .expect("metadata");
@@ -479,7 +630,7 @@ fn status_reports_running_task_when_pid_alive() {
         .spawn()
         .expect("spawn sleep");
     let pid = i32::try_from(child.id()).expect("pid fits in i32");
-    fs::write(store_root.join(format!("{task_id}.pid")), pid.to_string()).expect("pid file");
+    fs::write(task_dir.join("task.pid"), pid.to_string()).expect("pid file");
 
     let mut cmd = Command::cargo_bin(BIN).expect("binary should build");
     cmd.env("HOME", home).args(["status", "--json", task_id]);
@@ -501,7 +652,7 @@ fn status_detects_archived_tasks() {
     let timestamp = "2024-05-04T09:10:11Z";
     let store_root = home.join(".codex").join("tasks");
     let archive_dir = store_root
-        .join("done")
+        .join("archive")
         .join("2024")
         .join("05")
         .join("04")
@@ -514,15 +665,11 @@ fn status_detects_archived_tasks() {
         "updated_at": timestamp
     });
     fs::write(
-        archive_dir.join(format!("{task_id}.json")),
+        archive_dir.join("task.json"),
         serde_json::to_string_pretty(&metadata).unwrap(),
     )
     .expect("metadata");
-    fs::write(
-        archive_dir.join(format!("{task_id}.result")),
-        "final outcome",
-    )
-    .expect("result");
+    fs::write(archive_dir.join("task.result"), "final outcome").expect("result");
 
     let mut cmd = Command::cargo_bin(BIN).expect("binary should build");
     cmd.env("HOME", home).args(["status", "--json", task_id]);

--- a/tests/worker.rs
+++ b/tests/worker.rs
@@ -9,14 +9,15 @@ const BIN: &str = "codex-tasks";
 fn worker_subcommand_writes_pid_file() {
     let tmp = tempdir().expect("tempdir");
     let task_id = "integration-worker";
-    let pid_path = tmp.path().join(format!("{task_id}.pid"));
+    let store_root = tmp.path().join(".codex").join("tasks");
+    let pid_path = store_root.join(task_id).join("task.pid");
 
     let mut cmd = Command::cargo_bin(BIN).expect("binary should build");
     cmd.arg("worker")
         .arg("--task-id")
         .arg(task_id)
         .arg("--store-root")
-        .arg(tmp.path())
+        .arg(&store_root)
         .env("CODEX_TASKS_EXIT_AFTER_START", "1")
         .env("CODEX_TASK_TITLE", "Integration Title")
         .env("CODEX_TASK_PROMPT", "Integration Prompt");


### PR DESCRIPTION
## Summary
- reorganize active task layout to live under per-task directories with unified filenames and update storage helpers accordingly
- implement the archive command to move stopped tasks into a dated archive hierarchy, update metadata, and surface ARCHIVED status across commands
- refresh docs and tests, including new CLI coverage for archiving and adjusted worker expectations for the new layout

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d17913cab4832e894435f0a3fd665d