### PR TITLE
Implement archive command and reorganize task storage

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -51,17 +51,17 @@
    - **Depends on:** Tasks 2 & 4
 
 9. **Implement `ls` command**
-   - Enumerate `tasks/` and `tasks/done/**` directories.
+   - Enumerate `tasks/` and `tasks/archive/**` directories.
    - Aggregate metadata for each task; support `--state` filters.
    - **Depends on:** Task 2
 
 10. **Implement `log` command**
     - Tail/read `<task_id>.log` with options `-n`, `-f` (follow).
-    - Respect archived tasks (log location under `done/…`).
+    - Respect archived tasks (log location under `archive/…`).
     - **Depends on:** Task 2
 
 11. **Implement `archive` command**
-    - Move task files to dated `done/` subdirectory.
+    - Move task files to dated `archive/` subdirectory.
     - Prevent archiving RUNNING tasks without `stop`.
     - **Depends on:** Tasks 2, 8
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,9 +1,7 @@
-use std::collections::VecDeque;
-use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use serde_json::json;
 
 use crate::storage::TaskStore;
@@ -112,7 +110,7 @@ fn load_status_record(store: &TaskStore, task_id: &str) -> Result<TaskStatusReco
             let derived_state = derive_active_state(&metadata.state, pid);
             metadata.state = derived_state;
             if metadata.last_result.is_none() {
-                metadata.last_result = read_result_file(&directory, &metadata.id)?;
+                metadata.last_result = paths.read_last_result()?;
             }
             Ok(TaskStatusRecord {
                 metadata,
@@ -128,89 +126,20 @@ fn load_status_record(store: &TaskStore, task_id: &str) -> Result<TaskStatusReco
                 return Err(err);
             }
 
-            let Some((directory, mut metadata)) = find_archived_metadata(store, task_id)? else {
+            let Some((paths, mut metadata)) = store.find_archived_task(task_id)? else {
                 bail!("task {task_id} was not found in the task store");
             };
             metadata.state = TaskState::Archived;
             if metadata.last_result.is_none() {
-                metadata.last_result = read_result_file(&directory, &metadata.id)?;
+                metadata.last_result = paths.read_last_result()?;
             }
             Ok(TaskStatusRecord {
                 metadata,
-                location: TaskLocation::Archived(directory),
+                location: TaskLocation::Archived(paths.directory().to_path_buf()),
                 pid: None,
             })
         }
     }
-}
-
-fn read_result_file(directory: &Path, task_id: &str) -> Result<Option<String>> {
-    let path = directory.join(format!("{}.result", task_id));
-    match fs::read_to_string(&path) {
-        Ok(contents) => Ok(Some(contents)),
-        Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
-        Err(err) => {
-            Err(err).with_context(|| format!("failed to read last result from {}", path.display()))
-        }
-    }
-}
-
-fn find_archived_metadata(
-    store: &TaskStore,
-    task_id: &str,
-) -> Result<Option<(PathBuf, TaskMetadata)>> {
-    let archive_root = store.archive_root();
-    if !archive_root.exists() {
-        return Ok(None);
-    }
-
-    let mut queue = VecDeque::from([archive_root]);
-    let target_file = format!("{}.json", task_id);
-
-    while let Some(dir) = queue.pop_front() {
-        let entries = match fs::read_dir(&dir) {
-            Ok(entries) => entries,
-            Err(err) if err.kind() == ErrorKind::NotFound => continue,
-            Err(err) => {
-                return Err(err).with_context(|| {
-                    format!("failed to read archive directory {}", dir.display())
-                });
-            }
-        };
-
-        for entry in entries {
-            let entry = entry.with_context(|| {
-                format!("failed to iterate archive directory {}", dir.display())
-            })?;
-            let path = entry.path();
-            if path.is_dir() {
-                queue.push_back(path);
-                continue;
-            }
-
-            if path
-                .file_name()
-                .is_some_and(|name| name == target_file.as_str())
-            {
-                let data = fs::read_to_string(&path).with_context(|| {
-                    format!("failed to read archived metadata at {}", path.display())
-                })?;
-                let metadata: TaskMetadata = serde_json::from_str(&data).with_context(|| {
-                    format!("failed to parse archived metadata at {}", path.display())
-                })?;
-                if metadata.id != task_id {
-                    continue;
-                }
-                let directory = path
-                    .parent()
-                    .map(Path::to_path_buf)
-                    .unwrap_or_else(|| store.archive_root());
-                return Ok(Some((directory, metadata)));
-            }
-        }
-    }
-
-    Ok(None)
 }
 
 fn derive_active_state(metadata_state: &TaskState, pid: Option<i32>) -> TaskState {

--- a/src/worker/launcher.rs
+++ b/src/worker/launcher.rs
@@ -49,7 +49,12 @@ pub fn spawn_worker(request: WorkerLaunchRequest) -> Result<Child> {
     command.arg("--task-id");
     command.arg(task_paths.id());
     command.arg("--store-root");
-    command.arg(task_paths.directory());
+    let store_root = task_paths
+        .directory()
+        .parent()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| task_paths.directory().to_path_buf());
+    command.arg(store_root);
 
     if let Some(title) = title {
         command.env(TITLE_ENV_VAR, title);

--- a/tests/worker.rs
+++ b/tests/worker.rs
@@ -9,14 +9,15 @@ const BIN: &str = "codex-tasks";
 fn worker_subcommand_writes_pid_file() {
     let tmp = tempdir().expect("tempdir");
     let task_id = "integration-worker";
-    let pid_path = tmp.path().join(format!("{task_id}.pid"));
+    let store_root = tmp.path().join(".codex").join("tasks");
+    let pid_path = store_root.join(task_id).join("task.pid");
 
     let mut cmd = Command::cargo_bin(BIN).expect("binary should build");
     cmd.arg("worker")
         .arg("--task-id")
         .arg(task_id)
         .arg("--store-root")
-        .arg(tmp.path())
+        .arg(&store_root)
         .env("CODEX_TASKS_EXIT_AFTER_START", "1")
         .env("CODEX_TASK_TITLE", "Integration Title")
         .env("CODEX_TASK_PROMPT", "Integration Prompt");


### PR DESCRIPTION
## Summary
- move active tasks into per-task directories with canonical filenames
- implement the archive command that moves completed tasks under archive/<YYYY>/<MM>/<DD>/<task_id>
- update CLI commands and storage helpers to support the new layout and archived lookups

## Testing
- cargo test

Closes #11