### PR TITLE
Improve task state lifecycle and refine ls output

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -243,6 +243,17 @@ impl TaskPaths {
         Ok(())
     }
 
+    /// Loads metadata, applies a mutation, persists it, and returns the updated record.
+    pub fn update_metadata<F>(&self, mutate: F) -> Result<TaskMetadata>
+    where
+        F: FnOnce(&mut TaskMetadata),
+    {
+        let mut metadata = self.read_metadata()?;
+        mutate(&mut metadata);
+        self.write_metadata(&metadata)?;
+        Ok(metadata)
+    }
+
     /// Loads structured metadata for the task from disk.
     pub fn read_metadata(&self) -> Result<TaskMetadata> {
         let path = self.metadata_path();

--- a/src/task.rs
+++ b/src/task.rs
@@ -73,6 +73,19 @@ impl TaskMetadata {
             initial_prompt: None,
         }
     }
+
+    /// Updates the `updated_at` timestamp to the current moment.
+    pub fn touch(&mut self) {
+        self.updated_at = Utc::now();
+    }
+
+    /// Sets the task state and refreshes the `updated_at` timestamp.
+    pub fn set_state(&mut self, state: TaskState) {
+        if self.state != state {
+            self.state = state;
+        }
+        self.touch();
+    }
 }
 
 mod serde_datetime {

--- a/src/worker/runner.rs
+++ b/src/worker/runner.rs
@@ -108,10 +108,10 @@ pub(crate) struct ChildHandles {
 }
 
 #[allow(dead_code)]
-pub(crate) async fn run_event_loop<R>(
+pub(crate) async fn run_event_loop<R, P>(
     mut child: Child,
     stdin: ChildStdin,
-    event_processor: &mut EventProcessorWithHumanOutput,
+    event_processor: &mut P,
     config: &Config,
     event_rx: &mut mpsc::UnboundedReceiver<Event>,
     input: R,
@@ -119,6 +119,7 @@ pub(crate) async fn run_event_loop<R>(
 ) -> Result<()>
 where
     R: AsyncRead + Unpin,
+    P: EventProcessor,
 {
     let mut writer = Some(BufWriter::new(stdin));
     let mut next_submission_id: u64 = 1;
@@ -265,8 +266,8 @@ where
 }
 
 #[allow(dead_code)]
-pub(crate) async fn handle_event(
-    event_processor: &mut EventProcessorWithHumanOutput,
+pub(crate) async fn handle_event<P: EventProcessor>(
+    event_processor: &mut P,
     event: Event,
     writer: &mut Option<BufWriter<ChildStdin>>,
     shutdown_acknowledged: &mut bool,
@@ -311,11 +312,11 @@ pub(crate) async fn initiate_shutdown(
 }
 
 #[allow(dead_code)]
-pub(crate) async fn process_user_line(
+pub(crate) async fn process_user_line<P: EventProcessor>(
     text: String,
     prompt: &mut Option<String>,
     printed_summary: &mut bool,
-    event_processor: &mut EventProcessorWithHumanOutput,
+    event_processor: &mut P,
     config: &Config,
     writer: &mut Option<BufWriter<ChildStdin>>,
     next_submission_id: &mut u64,


### PR DESCRIPTION
## Summary
- ensure task metadata reflects real worker lifecycle (start, send, stop, archive)
- update workers to persist state transitions as Codex events arrive
- adjust AGENTS.md
Cargo.lock
Cargo.toml
docs
src
target
tests
third_party to show active tasks by default, add , and accept multi-state filters
- refresh docs and tests to cover the new behaviors

## Testing
- cargo test

Closes #12