### PR TITLE
fix: wait for log file before follow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2025-09-27
+### Fixed
+- `codex-tasks log -f` now waits for the task log file to appear before streaming, so it can be chained directly after `start`.
+
 ## [0.3.1] - 2025-09-27
 ### Added
 - `archive -a/--all` bulk-archives every task currently in `STOPPED` or `DIED` state.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "codex-tasks"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-tasks"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- poll for the log file when  is used so the CLI tolerates immediate follow after 
- cover the race with an integration-style CLI test that creates the log asynchronously
- bump version to 0.3.2 and document the fix in the changelog

## Testing
- cargo test

Resolves #50
