### PR TITLE
Update docs for codex exec backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Updated README and core documentation to describe the `codex exec` backend, thread ID identifiers, and the latest task lifecycle.
+
 ## [0.3.2] - 2025-09-27
 ### Fixed
 - `codex-tasks log -f` now waits for the task log file to appear before streaming, so it can be chained directly after `start`.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,7 +1,7 @@
 # Product Requirements – `codex-tasks`
 
 ## 1. Overview
-`codex-tasks` is a standalone CLI for launching and managing multiple Codex sessions in the background. Each session ("task") runs as its own helper process built on the existing `codex-task` implementation. The helper process is responsible for starting `codex proto`, streaming and rendering its transcript, and maintaining a simple filesystem-based “database” under `~/.codex/tasks`.
+`codex-tasks` is a standalone CLI for launching and managing multiple Codex sessions in the background. Each session ("task") is anchored by a Codex `thread_id` and advances through successive `codex exec --json` or `codex exec resume` invocations while the CLI records transcripts and lightweight metadata under `~/.codex/tasks`.
 
 ## 2. Goals
 - Allow users to start Codex jobs that continue running after the CLI exits.
@@ -11,7 +11,7 @@
 
 ## 3. CLI surface
 ```
-codex-tasks start [-t <title>] [--config-file <PATH>] [--working-dir <DIR>] [--repo <URL>] [--repo-ref <REF>] [prompt]
+codex-tasks start [-t <title>] [--config-file <PATH>] [--working-dir <DIR>] [--repo <URL>] [--repo-ref <REF>] <prompt>
 codex-tasks send <task_id> <prompt>
 codex-tasks status <task_id>
 codex-tasks log [--json] [-f] [-n <lines>] <task_id>
@@ -20,38 +20,36 @@ codex-tasks ls [--state <STATE> ...]
 codex-tasks archive <task_id>
 ```
 ### 3.1 `start`
-- Generate a new UUID (`task_id`).
-- Create task files in `~/.codex/tasks/` (`pid`, `pipe`, `log`, `result`).
-- Fork a helper process (the “task worker”).
-  - Worker launches `codex proto`, reusing the current `codex-task` I/O pipeline.
-  - If an initial prompt is provided, send it immediately.
+- Requires an initial prompt (supplied as an argument or via `-`/stdin).
+- Forks a helper process (the “task worker”) that immediately launches `codex exec --json` using the selected working directory and config overrides.
+- Buffers JSON events until a `thread.started` event arrives, then persists task files in `~/.codex/tasks/<thread_id>/` (`task.json`, `task.log`, `task.result`, `task.pid`) and prints the Codex `thread_id` (the canonical task identifier) to stdout.
 - Optional inputs that tailor worker launch:
-  - `--config-file PATH`: load a custom `config.toml` for Codex with the path’s parent treated as `CODEX_HOME`.
-  - `--working-dir DIR`: run `codex proto` from this directory (created if missing, unless repo cloning is requested). If omitted, the worker inherits the CLI's current directory and the value is recorded in task metadata for future `send` calls.
+  - `--config-file PATH`: load a custom `config.toml` (must be named `config.toml`). The worker sets `CODEX_HOME` to that file’s parent before invoking `codex exec`.
+  - `--working-dir DIR`: run `codex exec` from this directory (created if missing, unless repo cloning is requested). If omitted, the worker records the CLI’s current directory for reuse on future prompts.
   - `--repo URL`: clone the Git repository into the parent of `DIR` and use the directory name as the clone target (requires `--working-dir`).
   - `--repo-ref REF`: checkout the named branch/tag/commit after cloning.
-- Return `task_id` to stdout.
 
 ### 3.2 `send`
-- Resolve the task directory and open `<task_id>.pipe`.
-- Write the prompt (newline-terminated UTF-8) so the worker can forward it to Codex.
+- Resolve the task directory, validate that the task is neither `ARCHIVED` nor `DIED`, and ensure no worker process is still running.
+- Spawn a new worker that resumes the existing `thread_id` by calling `codex exec --json resume <thread_id> "<prompt>"`.
+- Record the updated `last_prompt` metadata before returning.
 
 ### 3.3 `status`
 - Inspect the task files and process state.
-- Determine status (`IDLE`, `RUNNING`, `STOPPED`, `ARCHIVED`, `DIED`).
+- Determine status (`RUNNING`, `STOPPED`, `ARCHIVED`, `DIED`) based on metadata and the presence of a live worker PID.
 - Output JSON or table with status, title (if any), timestamps, and last result (if available).
 
 ### 3.4 `log`
 - Stream the transcript from `<task_id>.log`. By default the CLI renders human-friendly output matching `codex exec`; `--json` streams raw JSONL events.
-- `-f/--follow` streams until the worker returns to `IDLE` (or reaches a terminal state), exiting automatically afterwards. Combine with `--forever`/`-F` to continue streaming indefinitely.
+- `-f/--follow` streams until the current invocation completes and the task transitions to `STOPPED` or `DIED`, exiting automatically afterwards. Combine with `--forever`/`-F` to continue streaming indefinitely.
 - `--forever`/`-F` implies `--follow` and retains the original "tail indefinitely" behavior for users who want to keep the stream open.
 - `-n/--lines <N>` restricts the initial dump to the last *N* lines before optionally following.
 - Intended as the primary observability tool without attaching a TTY to the worker.
 
 ### 3.5 `stop`
-- Notify the worker to send `shutdown` to Codex, wait for `ShutdownComplete`, and clean up (`.pid`, `.pipe`).
-- After graceful exit, status becomes `STOPPED`.
-- `-a/--all` stops every task currently in the `IDLE` state, issuing the same graceful shutdown flow for each worker.
+- Inspect the task’s recorded PID and, if the worker is still running, send `SIGTERM` followed by a timed wait for the process to exit cleanly.
+- After graceful exit, status becomes `STOPPED` and the PID file is removed.
+- `-a/--all` stops every task that currently has a live worker process, printing per-task outcomes.
 
 ### 3.6 `ls`
 - List active tasks in `~/.codex/tasks/`.
@@ -64,65 +62,64 @@ codex-tasks archive <task_id>
 - Status becomes `ARCHIVED` for each archived task.
 
 ## 4. Task data model
-- `task_id`: UUID (e.g., `7df7c873-...`).
+- `task_id`: Codex `thread_id` returned by the service (opaque string).
 - `title`: optional string provided at `start`.
-- `state`: one of {`IDLE`, `RUNNING`, `STOPPED`, `ARCHIVED`, `DIED`}.
+- `state`: one of {`RUNNING`, `STOPPED`, `ARCHIVED`, `DIED`}.
 - `created_at`, `updated_at` timestamps (recorded by worker).
-- `last_result`: UTF-8 text of the most recent Codex answer (available in `IDLE`, `STOPPED`, `ARCHIVED`).
+- `last_result`: UTF-8 text of the most recent Codex answer (available in `STOPPED` or `ARCHIVED`).
 - `last_prompt`: UTF-8 text of the most recent user prompt (updated on `start` and each `send`).
 - `working_dir`: absolute path used when launching Codex; defaults to the CLI's current directory if `--working-dir` was not provided.
 
 ## 5. Filesystem layout (`~/.codex/tasks/`)
 - Active tasks live under `~/.codex/tasks/<task_id>/`, keeping related files grouped together.
-- Each task directory stores `task.pid`, `task.pipe`, `task.log`, `task.result`, and `task.json`.
+- Each task directory stores `task.pid`, `task.log`, `task.result`, and `task.json`. Legacy tasks created before the `codex exec` migration may also include `task.pipe`.
 - Archived tasks move to `~/.codex/tasks/archive/<YYYY>/<MM>/<DD>/<task_id>/` with the same filenames.
 
 ```
 ~/.codex/tasks/
   <task_id>/
     task.pid
-    task.pipe
     task.log
     task.result
     task.json
   archive/<YYYY>/<MM>/<DD>/<task_id>/...
 ```
-- When a task is STOPPED or DIED, `.pid` and `.pipe` are removed; log/result remain.
+- When a task is STOPPED or DIED, the worker removes the `.pid` file (and any legacy `.pipe` file); log/result remain.
 - `task.log` contains a JSON Lines stream of Codex events (`thread.started`, `turn.completed`, `item.completed`, etc.) including synthetic `user_message` entries for prompts and `stderr` entries for diagnostics. CLI rendering converts this stream into the familiar human transcript.
 
 ## 6. Worker lifecycle
-1. **Spawn**: parent CLI forks a worker, writes initial files, and returns `task_id`.
-2. **Initialization**: worker launches `codex proto` with piped stdin/stdout, replicating existing `codex-task` logic, honoring any custom config file and working directory derived from the CLI flags.
-3. **Main loop**:
-   - Keep `<task_id>.pipe` open for reading; translate each UTF-8 segment into a prompt. The worker tolerates writers connecting and disconnecting repeatedly, only reacting to the explicit `/quit` sentinel.
-   - Forward Codex events to the renderer, appending to `<task_id>.log` and updating `<task_id>.result` when appropriate.
-4. **Shutdown**:
-   - `stop` writes `/quit` into the pipe. The worker interprets this sentinel, sends `{"id":"sub-…","op":{"type":"shutdown"}}`, and begins the shutdown sequence.
-   - Wait for `ShutdownComplete`; close pipes; kill process on timeout (5 s) with logging.
-5. **Termination**: remove `.pid`/`.pipe`. If exit was graceful → `STOPPED`; if worker dies unexpectedly → `DIED`.
+1. **Spawn**: the CLI forks a worker with the prompt, optional title, and configuration overrides. For follow-up prompts, the worker receives the existing `thread_id`.
+2. **Initialization**: the worker prepares the task store layout and loads any existing metadata so it can reuse stored config paths or working directories.
+3. **Invocation**:
+   - For a new task, invoke `codex exec --json "<prompt>"`. Buffer events until `thread.started` arrives, then write metadata/log files under the emitted `thread_id` and flush buffered lines.
+   - For follow-up prompts, invoke `codex exec --json resume <thread_id> "<prompt>"` immediately, appending `user_message` and streamed events to the existing log.
+   - Record the worker PID and update metadata (state → `RUNNING`, refresh `last_prompt`).
+4. **Completion**:
+   - Wait for the process to exit. On success, promote the `--output-last-message` artifact into `task.result` and set state → `STOPPED`. On failure, mark the task `DIED`.
+5. **Finalization**: flush buffered log output, remove the PID file, and exit. Any follow-up prompts will spawn a fresh worker repeating the flow above.
 
 ## 7. State transitions
 ```
-(start) → IDLE or RUNNING (if prompt) ↔ RUNNING (during codex call)
-RUNNING → IDLE (on successful completion)
-stop → STOPPED (after graceful shutdown)
-worker crash / missing PID → DIED
+(start) → RUNNING (initial codex exec invocation)
+RUNNING → STOPPED (invocation exits successfully)
+RUNNING → DIED (exec process fails or crashes)
+stop → STOPPED (signal worker and wait for exit)
 archive → ARCHIVED (files moved to archive/…)
 ```
 
 ## 8. Error handling & logging
-- All Codex interaction logs go to `<task_id>.log` (exact renderer from `codex-task`).
+- All Codex interaction logs go to `<task_id>.log` (same renderer as `codex exec`).
 - `status` detects:
   - Missing `task.pid` but existing log ⇒ `DIED`.
   - Archived tasks based on directory location.
 - CLI commands exit non-zero with a clear message if:
   - Task ID not found.
-  - Pipe missing (STOPPED/ARCHIVED tasks) unless command is `status` or `ls`.
-  - Worker fails to start (`start` surfaces error).
+  - Task is `ARCHIVED` or `DIED` when attempting to send a prompt.
+  - Worker fails to start or `codex exec` exits with an error code.
 
 ## 9. Reuse of existing code
-- Copy or refactor the current `codex-task` communication layer (spawning `codex proto`, streaming events, UTF-8 line handling, shutdown procedure) into a reusable module consumed by each worker.
-- Reuse the transcript renderer to ensure output parity.
+- Reuse the `codex-task` transcript renderer to convert JSON events into human-readable logs.
+- Share the existing storage helpers for metadata, log/result persistence, and archiving.
 
 ## 10. Future enhancements (out of scope for initial version)
 - Optional metadata cache (`meta.json`) to avoid scanning directories on `ls`.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,10 +48,10 @@ pub struct StartArgs {
     /// Optional human readable title for the new task.
     #[arg(short = 't', long)]
     pub title: Option<String>,
-    /// Path to a custom Codex config file that should be used by `codex proto`.
+    /// Path to a custom Codex config file that should be used by `codex exec`.
     #[arg(long = "config-file", value_name = "PATH")]
     pub config_file: Option<PathBuf>,
-    /// Working directory where `codex proto` should run.
+    /// Working directory where `codex exec` should run.
     #[arg(long = "working-dir", value_name = "DIR")]
     pub working_dir: Option<PathBuf>,
     /// Git repository to clone into the working directory before starting.
@@ -163,7 +163,7 @@ pub struct WorkerArgs {
     /// Optional Codex config file that should override the default configuration.
     #[arg(long = "config-path")]
     pub config_path: Option<PathBuf>,
-    /// Optional working directory for launching `codex proto`.
+    /// Optional working directory for launching `codex exec`.
     #[arg(long = "working-dir")]
     pub working_dir: Option<PathBuf>,
 }


### PR DESCRIPTION
Closes #64

## Summary
- align README and product docs with the codex exec backend and thread ID identifiers
- update implementation plan to describe exec invocations instead of fifo pipes
- document the refresh in the changelog and fix CLI help comments

## Testing
- not run (docs only)
