### PR TITLE
Plan MCP server mode implementation

### DIFF
--- a/docs/features/mcp-server/plan.md
+++ b/docs/features/mcp-server/plan.md
@@ -1,0 +1,76 @@
+# Implementation Plan – MCP Server Mode
+
+## Legend
+- **Task** – discrete engineering deliverable.
+- **Depends on** – prerequisite tasks that must be completed first.
+
+## Workstreams & Tasks
+
+1. **MCP Transport Skeleton**
+   - Add the `codex-tasks mcp` CLI entry point (flag parsing, config loading stub).
+   - Wire up stdio-based MCP server initialization using the chosen protocol crate.
+   - Handle `initialize`, `ping`, and `shutdown` requests with placeholder responses.
+
+2. **Configuration Plumbing**
+   - Implement config loader (`--store-root`, `--config`, `--allow-unsafe`).
+   - Validate inputs and propagate settings into the server context.
+   - **Depends on:** Task 1
+
+3. **Shared Task Services & Tool Layer**
+   - Extract reusable service functions from existing CLI commands (start/send/status/log/stop/list/archive) so both CLI and MCP paths call the same logic.
+   - Introduce a thin adapter layer that turns MCP tool invocations into calls to the shared services.
+   - Ensure the CLI subcommands are refactored to consume the shared services without regressing current behaviour.
+   - Normalize error handling: map service errors into MCP error envelopes with stable codes.
+   - **Depends on:** Task 1
+
+4. **Streaming & Concurrency Support**
+   - Extend the adapter for `task.log` to support streaming responses (follow mode with cancellation).
+   - Ensure long-running operations spawn async tasks with cooperative cancellation.
+   - Add client-driven cancellation hooks (e.g., abort handles when MCP issues `cancel`).
+   - **Depends on:** Task 3
+
+5. **State & Store Integration**
+   - Thread store configuration through adapters, ensuring commands use the specified root.
+   - Audit commands for stdout/tty assumptions; add abstractions where necessary (e.g., injecting writers for MCP responses instead of printing).
+   - Expose shared listing helpers that gather the same data the CLI prints while returning structured payloads for MCP clients.
+   - **Depends on:** Task 3
+
+6. **Diagnostics & Logging**
+   - Route server diagnostics to stderr with structured logging (level filtering, optional `--verbose`).
+   - Emit per-invocation summaries for observability without contaminating MCP stdout.
+   - **Depends on:** Tasks 2 & 3
+
+7. **Testing & Tooling**
+   - Build a lightweight MCP client harness (Tokio-based) for integration tests.
+   - Write tests covering:
+     - Successful `initialize`/`shutdown` lifecycle.
+     - `task.start` + `task.status` round trip.
+     - `task.log` streaming + cancellation.
+   - Add unit tests for config parsing and error mapping.
+   - **Depends on:** Tasks 2–4
+
+8. **Documentation & Release Prep**
+   - Update README with a new MCP section (usage, available tools, sample JSON payloads).
+   - Document configuration file schema in `docs/features/mcp-server/prd.md` or a dedicated reference.
+   - Add changelog entry and release notes snippet.
+   - **Depends on:** Tasks 2–7
+
+## Timeline & Sequencing
+1. Skeleton (Task 1)
+2. Config/Auth (Task 2)
+3. Tool Adapters (Task 3)
+4. Store & Logging (Tasks 5 & 6) in parallel once adapters exist
+5. Streaming/Cancellation (Task 4)
+6. Testing (Task 7)
+7. Docs/Release (Task 8)
+
+## Risks & Mitigations
+- **Adapter output incompatibility** – some CLI commands write directly to stdout; mitigate by refactoring to accept trait-based writers before wiring adapters.
+- **Streaming back-pressure** – large log outputs could overwhelm clients; add chunking and optional line limits.
+- **Protocol mismatch** – stay aligned with MCP spec; add compatibility tests with the official client library.
+
+## Open Questions
+1. Do we expose advanced CLI flags (repo cloning, JSON output) immediately or phase them in?
+2. Should `task.stop` support `--all` through MCP, and is it gated behind `--allow-unsafe`?
+3. How do we map CLI stream formatting (ANSI colors, etc.) into MCP responses—strip or preserve?
+4. Do we need metrics (counts, durations) emitted somewhere for ops visibility?


### PR DESCRIPTION
Closes #68

## Summary
- add an implementation plan detailing the workstreams for MCP server mode
- outline task dependencies from transport skeleton through docs/release
- capture risks, mitigations, and open questions for downstream discussion

## Testing
- not run (docs only)
