### PR TITLE
Extend status command selectors and wait options

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The CLI exposes several subcommands; run `codex-tasks <command> --help` for full
 | --- | --- |
 | `codex-tasks start [-t <title>] <prompt>` | Create a new task with an initial prompt. |
 | `codex-tasks send <task_id> <prompt>` | Send another prompt to an existing task. |
-| `codex-tasks status [--json] <task_id>` | Show live status, metadata, and the last prompt/result. |
+| `codex-tasks status [OPTIONS] [<task_id> ...]` | Show status for specific tasks or selectors (supports `-a/--all`, `-A/--all-running`, `--wait`, and `--wait-any`). |
 | `codex-tasks log [--json] [-f\|--follow] [--forever] [-n <lines>] <task_id>` | Stream or tail the transcript for a task (human transcript by default, raw JSONL with `--json`). |
 | `codex-tasks stop [-a\|--all] [<task_id>]` | Gracefully shut down a worker; use `-a/--all` to stop every running task. |
 | `codex-tasks ls [-a\|--all] [--state <STATE> ...]` | List active tasks, optionally including archived ones and filtering by state. |
@@ -67,6 +67,15 @@ codex-tasks log -f "$TASK_ID"
 codex-tasks stop "$TASK_ID"
 codex-tasks stop -a   # stop all remaining running tasks in bulk
 codex-tasks archive "$TASK_ID"
+```
+
+Use the extended status selectors to observe groups of tasks:
+```bash
+# Inspect every running task and wait for at least one to finish
+codex-tasks status --wait-any --all-running
+
+# Render a combined JSON snapshot for several known task IDs
+codex-tasks status --json task-a task-b task-c
 ```
 
 ## Additional documentation

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,8 +84,26 @@ pub struct StatusArgs {
     /// Control how timestamps are rendered when using human-readable output.
     #[arg(long = "time-format", value_enum, default_value_t = TimeFormat::Human)]
     pub time_format: TimeFormat,
-    /// Identifier of the task that should be inspected.
-    pub task_id: String,
+    /// Inspect every known task (including archived tasks).
+    #[arg(short = 'a', long = "all", conflicts_with = "all_running")]
+    pub all: bool,
+    /// Inspect every currently running task.
+    #[arg(short = 'A', long = "all-running", conflicts_with = "all")]
+    pub all_running: bool,
+    /// Wait for all selected tasks to reach a terminal state before returning.
+    #[arg(long, conflicts_with = "wait_any")]
+    pub wait: bool,
+    /// Wait until at least one selected task reaches a terminal state before returning.
+    #[arg(long = "wait-any", conflicts_with = "wait")]
+    pub wait_any: bool,
+    /// Identifier(s) of the task(s) that should be inspected.
+    #[arg(
+        value_name = "TASK_ID",
+        num_args = 1..,
+        required_unless_present_any = ["all", "all_running"],
+        conflicts_with_all = ["all", "all_running"]
+    )]
+    pub task_ids: Vec<String>,
 }
 
 /// Arguments for the `log` subcommand.

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,8 +1,12 @@
-use anyhow::Result;
+use std::collections::HashSet;
+use std::thread::sleep;
+use std::time::Duration;
+
+use anyhow::{Result, bail};
 use serde_json::json;
 
 use crate::cli::StatusArgs;
-use crate::tasks::{TaskService, TaskStatusSnapshot};
+use crate::tasks::{ListTasksOptions, TaskService, TaskState, TaskStatusSnapshot};
 use crate::timefmt::{TimeFormat, format_time};
 
 /// Output format supported by the status command.
@@ -12,12 +16,23 @@ pub enum StatusFormat {
     Json,
 }
 
+/// Wait semantics supported by the status command.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WaitMode {
+    None,
+    All,
+    Any,
+}
+
 /// Options accepted by the status command handler.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StatusCommandOptions {
-    pub task_id: String,
+    pub task_ids: Vec<String>,
+    pub include_all: bool,
+    pub include_all_running: bool,
     pub format: StatusFormat,
     pub time_format: TimeFormat,
+    pub wait_mode: WaitMode,
 }
 
 pub fn handle_status(args: StatusArgs) -> Result<()> {
@@ -27,26 +42,98 @@ pub fn handle_status(args: StatusArgs) -> Result<()> {
         StatusFormat::Human
     };
 
+    let wait_mode = if args.wait_any {
+        WaitMode::Any
+    } else if args.wait {
+        WaitMode::All
+    } else {
+        WaitMode::None
+    };
+
     run(StatusCommandOptions {
-        task_id: args.task_id,
+        task_ids: args.task_ids,
+        include_all: args.all,
+        include_all_running: args.all_running,
         format,
         time_format: args.time_format,
+        wait_mode,
     })
 }
 
 fn run(options: StatusCommandOptions) -> Result<()> {
     let service = TaskService::with_default_store(false)?;
-    let status = service.get_status(&options.task_id)?;
+    let targets = resolve_targets(&service, &options)?;
+    if targets.is_empty() {
+        bail!("no tasks matched the requested selectors");
+    }
+
+    let records = collect_statuses(&service, &targets, options.wait_mode)?;
 
     match options.format {
-        StatusFormat::Human => render_human(&status, options.time_format),
-        StatusFormat::Json => render_json(&status)?,
+        StatusFormat::Human => render_human(&records, options.time_format),
+        StatusFormat::Json => render_json(&records)?,
     }
 
     Ok(())
 }
 
-fn render_human(record: &TaskStatusSnapshot, time_format: TimeFormat) {
+fn resolve_targets(service: &TaskService, options: &StatusCommandOptions) -> Result<Vec<String>> {
+    if options.include_all {
+        let entries = service.list_tasks(ListTasksOptions {
+            include_archived: true,
+            ..Default::default()
+        })?;
+        return Ok(entries.into_iter().map(|entry| entry.metadata.id).collect());
+    }
+
+    if options.include_all_running {
+        let mut list_options = ListTasksOptions::default();
+        list_options.states.push(TaskState::Running);
+        let entries = service.list_tasks(list_options)?;
+        return Ok(entries.into_iter().map(|entry| entry.metadata.id).collect());
+    }
+
+    let mut seen = HashSet::new();
+    let mut targets = Vec::new();
+    for task_id in &options.task_ids {
+        if seen.insert(task_id.clone()) {
+            targets.push(task_id.clone());
+        }
+    }
+    Ok(targets)
+}
+
+fn collect_statuses(
+    service: &TaskService,
+    task_ids: &[String],
+    wait_mode: WaitMode,
+) -> Result<Vec<TaskStatusSnapshot>> {
+    const POLL_INTERVAL_MS: u64 = 300;
+
+    loop {
+        let mut records = Vec::with_capacity(task_ids.len());
+        for task_id in task_ids {
+            records.push(service.get_status(task_id)?);
+        }
+
+        if wait_mode.is_satisfied(&records) {
+            return Ok(records);
+        }
+
+        sleep(Duration::from_millis(POLL_INTERVAL_MS));
+    }
+}
+
+fn render_human(records: &[TaskStatusSnapshot], time_format: TimeFormat) {
+    for (index, record) in records.iter().enumerate() {
+        if index > 0 {
+            println!();
+        }
+        render_human_record(record, time_format);
+    }
+}
+
+fn render_human_record(record: &TaskStatusSnapshot, time_format: TimeFormat) {
     println!("Task ID: {}", record.metadata.id);
     if let Some(title) = &record.metadata.title {
         println!("Title: {}", title);
@@ -85,8 +172,19 @@ fn render_human(record: &TaskStatusSnapshot, time_format: TimeFormat) {
     }
 }
 
-fn render_json(record: &TaskStatusSnapshot) -> Result<()> {
-    let payload = json!({
+fn render_json(records: &[TaskStatusSnapshot]) -> Result<()> {
+    if records.len() == 1 {
+        let payload = status_to_json(&records[0]);
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else {
+        let payload: Vec<_> = records.iter().map(status_to_json).collect();
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    }
+    Ok(())
+}
+
+fn status_to_json(record: &TaskStatusSnapshot) -> serde_json::Value {
+    json!({
         "id": record.metadata.id.clone(),
         "title": record.metadata.title.clone(),
         "state": record.metadata.state.clone(),
@@ -96,7 +194,22 @@ fn render_json(record: &TaskStatusSnapshot) -> Result<()> {
         "last_result": record.metadata.last_result.clone(),
         "working_dir": record.metadata.working_dir.clone(),
         "pid": record.pid,
-    });
-    println!("{}", serde_json::to_string_pretty(&payload)?);
-    Ok(())
+    })
+}
+
+impl WaitMode {
+    fn is_satisfied(self, records: &[TaskStatusSnapshot]) -> bool {
+        match self {
+            WaitMode::None => true,
+            WaitMode::All => records.iter().all(|record| is_terminal(record)),
+            WaitMode::Any => records.iter().any(|record| is_terminal(record)),
+        }
+    }
+}
+
+fn is_terminal(record: &TaskStatusSnapshot) -> bool {
+    matches!(
+        record.metadata.state,
+        TaskState::Stopped | TaskState::Archived | TaskState::Died
+    )
 }


### PR DESCRIPTION
## Summary
- add CLI support for bulk status selection via multiple IDs, --all, and --all-running flags
- implement wait semantics so status can block until all or any tasks reach a terminal state
- document the new options and cover them with integration tests to avoid regressions

## Testing
- cargo test --test cli status_supports_multiple_identifiers_in_json
- cargo test --test cli status_all_selector_includes_archived_tasks
- cargo test --test cli status_wait_blocks_until_task_reaches_terminal_state
- cargo test --test cli status_wait_any_returns_when_first_task_completes
